### PR TITLE
Support binary GLTF with embedded buffers

### DIFF
--- a/android_debug_build32.sh
+++ b/android_debug_build32.sh
@@ -1,3 +1,16 @@
-cmake --trace -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=android-22 -DANDROID_FORCE_ARM_BUILD=TRUE -DCMAKE_INSTALL_PREFIX=install -DANDROID_STL=c++_shared -DANDROID_STL_FORCE_FEATURES=ON -DCMAKE_TOOLCHAIN_FILE=$NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_TOOLCHAIN=clang
-make -j12
+ANDROID_SDK=~/Android/Sdk
+NDKROOT=$ANDROID_SDK/ndk-bundle
+$ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
+	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
+	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=armeabi-v7a \
+	-DANDROID_NATIVE_API_LEVEL=android-22 \
+	-DANDROID_FORCE_ARM_BUILD=TRUE \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_STL_FORCE_FEATURES=ON \
+	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
+	-DANDROID_TOOLCHAIN=clang
+$NDKROOT/prebuilt/linux-x86_64/bin/make -j12
 

--- a/android_debug_build64.sh
+++ b/android_debug_build64.sh
@@ -1,3 +1,16 @@
-cmake --trace -G "Unix Makefiles" -DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a -DCMAKE_BUILD_TYPE=Debug -DANDROID_ABI=arm64-v8a -DANDROID_NATIVE_API_LEVEL=android-22 -DANDROID_FORCE_ARM_BUILD=TRUE -DCMAKE_INSTALL_PREFIX=install -DANDROID_STL=c++_shared -DANDROID_STL_FORCE_FEATURES=ON -DCMAKE_TOOLCHAIN_FILE=$NDK_HOME/build/cmake/android.toolchain.cmake -DANDROID_TOOLCHAIN=clang
-make -j12
+ANDROID_SDK=~/Android/Sdk
+NDKROOT=$ANDROID_SDK/ndk-bundle
+$ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
+	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
+	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=arm64-v8a \
+	-DANDROID_NATIVE_API_LEVEL=android-22 \
+	-DANDROID_FORCE_ARM_BUILD=TRUE \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_STL_FORCE_FEATURES=ON \
+	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
+	-DANDROID_TOOLCHAIN=clang
+$NDKROOT/prebuilt/linux-x86_64/bin/make -j12
 

--- a/android_release_build32.sh
+++ b/android_release_build32.sh
@@ -1,6 +1,17 @@
-cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=android-22 -DANDROID_FORCE_ARM_BUILD=TRUE -DCMAKE_INSTALL_PREFIX=install -DANDROID_STL=c++_shared -DANDROID_STL_FORCE_FEATURES=ON -DCMAKE_TOOLCHAIN_FILE=$NDK_HOME/build/cmake/android.toolchain.cmake  -DANDROID_TOOLCHAIN=clang
-make -j12
-cd lib
-cp libassimp.so libassimp.so.debug
-$ANDROID_SDK/ndk-bundle/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/strip libassimp.so
+ANDROID_SDK=~/Android/Sdk
+NDKROOT=$ANDROID_SDK/ndk-bundle
+$ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
+	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
+	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DANDROID_ABI=armeabi-v7a \
+	-DANDROID_NATIVE_API_LEVEL=android-22 \
+	-DANDROID_FORCE_ARM_BUILD=TRUE \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_STL_FORCE_FEATURES=ON \
+	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
+	-DANDROID_TOOLCHAIN=clang
+$NDKROOT/prebuilt/linux-x86_64/bin/make -j12
+$NDKROOT/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/strip lib/libassimp.so
 

--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -889,7 +889,7 @@ namespace glTF2
     //         Ref<Accessor> scale;          //!< Accessor reference to a buffer storing a array of three-component floating-point vectors.
     //         Ref<Accessor> translation;    //!< Accessor reference to a buffer storing a array of three-component floating-point vectors.
     //     };
-        
+
 
     //     std::vector<AnimChannel> Channels;            //!< Connect the output values of the key-frame animation to a specific node in the hierarchy.
     //     AnimParameters Parameters;                    //!< The samplers that interpolate between the key-frames.
@@ -931,7 +931,7 @@ namespace glTF2
                 std::string path;        //!< The name of property of the node to animate ("translation", "rotation", or "scale").
             } target;
         };
-        
+
         std::vector<AnimChannel> Channels;            //!< Connect the output values of the key-frame animation to a specific node in the hierarchy.
         std::vector<AnimSampler> Samplers;         //!< The parameterized inputs representing the key-frame data.
 
@@ -1118,6 +1118,9 @@ namespace glTF2
 
         //! Enables binary encoding on the asset
         void SetAsBinary();
+
+        //! Read GLTF binaryu chunk
+        bool ReadBinaryChunk(IOStream& stream);
 
         //! Search for an available name, starting from the given strings
         std::string FindUniqueID(const std::string& str, const char* suffix);

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -464,34 +464,40 @@ void glTF2Importer::ImportMeshes(glTF2::Asset& r)
 
                     if (target.position.size() > 0) {
                         aiVector3D *positionDiff = nullptr;
-                        target.position[0]->ExtractData(positionDiff);
-                        for(unsigned int vertexId = 0; vertexId < aim->mNumVertices; vertexId++) {
-                            aiAnimMesh.mVertices[vertexId] += positionDiff[vertexId];
+                        if (target.position[0]->ExtractData(positionDiff)) {
+                            for (unsigned int vertexId = 0;
+                                 vertexId < aim->mNumVertices; vertexId++) {
+                                aiAnimMesh.mVertices[vertexId] += positionDiff[vertexId];
+                            }
+                            delete[] positionDiff;
                         }
-                        delete [] positionDiff;
                     }
                     if (target.normal.size() > 0) {
                         aiVector3D *normalDiff = nullptr;
-                        target.normal[0]->ExtractData(normalDiff);
-                        for(unsigned int vertexId = 0; vertexId < aim->mNumVertices; vertexId++) {
-                            aiAnimMesh.mNormals[vertexId] += normalDiff[vertexId];
+                        if (target.normal[0]->ExtractData(normalDiff)) {
+                            for (unsigned int vertexId = 0;
+                                 vertexId < aim->mNumVertices; vertexId++) {
+                                aiAnimMesh.mNormals[vertexId] += normalDiff[vertexId];
+                            }
+                            delete[] normalDiff;
                         }
-                        delete [] normalDiff;
                     }
                     if (target.tangent.size() > 0) {
                         Tangent *tangent = nullptr;
                         attr.tangent[0]->ExtractData(tangent);
-
                         aiVector3D *tangentDiff = nullptr;
-                        target.tangent[0]->ExtractData(tangentDiff);
-
-                        for (unsigned int vertexId = 0; vertexId < aim->mNumVertices; ++vertexId) {
-                            tangent[vertexId].xyz += tangentDiff[vertexId];
-                            aiAnimMesh.mTangents[vertexId] = tangent[vertexId].xyz;
-                            aiAnimMesh.mBitangents[vertexId] = (aiAnimMesh.mNormals[vertexId] ^ tangent[vertexId].xyz) * tangent[vertexId].w;
+                        if (target.tangent[0]->ExtractData(tangentDiff)) {
+                            for (unsigned int vertexId = 0;
+                                 vertexId < aim->mNumVertices; ++vertexId) {
+                                tangent[vertexId].xyz += tangentDiff[vertexId];
+                                aiAnimMesh.mTangents[vertexId] = tangent[vertexId].xyz;
+                                aiAnimMesh.mBitangents[vertexId] =
+                                    (aiAnimMesh.mNormals[vertexId] ^ tangent[vertexId].xyz) *
+                                    tangent[vertexId].w;
+                            }
+                            delete[] tangent;
+                            delete[] tangentDiff;
                         }
-                        delete [] tangent;
-                        delete [] tangentDiff;
                     }
                     if (mesh.weights.size() > i) {
                         aiAnimMesh.mWeight = mesh.weights[i];
@@ -979,7 +985,7 @@ void glTF2Importer::ImportAnimations(glTF2::Asset& r)
         //condense all channels belonging to one node into one channel
 
 
-        //using comparator for map which doesnt care about ordering. 
+        //using comparator for map which doesnt care about ordering.
         //should replace by unordered_map when using c++11.
         std::map< aiString, aiNodeAnim* , mycomp> uniqueNodes;
 

--- a/intel_debug_build32.sh
+++ b/intel_debug_build32.sh
@@ -3,8 +3,8 @@ NDKROOT=$ANDROID_SDK/ndk-bundle
 $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
 	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DANDROID_ABI=arm64-v8a \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=x86 \
 	-DANDROID_NATIVE_API_LEVEL=android-22 \
 	-DANDROID_FORCE_ARM_BUILD=TRUE \
 	-DCMAKE_INSTALL_PREFIX=install \
@@ -13,5 +13,4 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
 	-DANDROID_TOOLCHAIN=clang
 $NDKROOT/prebuilt/linux-x86_64/bin/make -j12
-$NDKROOT/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/aarch64-linux-android/bin/strip lib/libassimp.so
 

--- a/intel_debug_build64.sh
+++ b/intel_debug_build64.sh
@@ -3,8 +3,8 @@ NDKROOT=$ANDROID_SDK/ndk-bundle
 $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
 	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DANDROID_ABI=arm64-v8a \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=x86_64 \
 	-DANDROID_NATIVE_API_LEVEL=android-22 \
 	-DANDROID_FORCE_ARM_BUILD=TRUE \
 	-DCMAKE_INSTALL_PREFIX=install \
@@ -13,5 +13,4 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
 	-DANDROID_TOOLCHAIN=clang
 $NDKROOT/prebuilt/linux-x86_64/bin/make -j12
-$NDKROOT/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/aarch64-linux-android/bin/strip lib/libassimp.so
 

--- a/intel_release_build32.sh
+++ b/intel_release_build32.sh
@@ -4,7 +4,7 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
 	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DANDROID_ABI=arm64-v8a \
+	-DANDROID_ABI=x86 \
 	-DANDROID_NATIVE_API_LEVEL=android-22 \
 	-DANDROID_FORCE_ARM_BUILD=TRUE \
 	-DCMAKE_INSTALL_PREFIX=install \
@@ -13,5 +13,4 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
 	-DANDROID_TOOLCHAIN=clang
 $NDKROOT/prebuilt/linux-x86_64/bin/make -j12
-$NDKROOT/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/aarch64-linux-android/bin/strip lib/libassimp.so
 

--- a/intel_release_build64.sh
+++ b/intel_release_build64.sh
@@ -4,7 +4,7 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/linux-x86_64/bin/make \
 	-DANDROID_LINKER_FLAGS=-Wl,--exclude-libs,libunwind.a  \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DANDROID_ABI=arm64-v8a \
+	-DANDROID_ABI=x86_64 \
 	-DANDROID_NATIVE_API_LEVEL=android-22 \
 	-DANDROID_FORCE_ARM_BUILD=TRUE \
 	-DCMAKE_INSTALL_PREFIX=install \
@@ -13,5 +13,4 @@ $ANDROID_SDK/cmake/3.6.4111459/bin/cmake --trace -G "Unix Makefiles" \
 	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
 	-DANDROID_TOOLCHAIN=clang
 $NDKROOT/prebuilt/linux-x86_64/bin/make -j12
-$NDKROOT/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/aarch64-linux-android/bin/strip lib/libassimp.so
 

--- a/winbuild32.sh
+++ b/winbuild32.sh
@@ -1,0 +1,13 @@
+cmake --trace  -G "MinGW Makefiles" \
+	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/windows-x86_64/bin/make.exe \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=armeabi-v7a \
+	-DANDROID_NATIVE_API_LEVEL=android-22 \
+	-DANDROID_FORCE_ARM_BUILD=TRUE \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_STL_FORCE_FEATURES=ON \
+	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
+	-DANDROID_TOOLCHAIN=clang
+$NDKROOT/prebuilt/windows-x86_64/bin/make.exe -j12
+

--- a/winbuild64.sh
+++ b/winbuild64.sh
@@ -1,0 +1,13 @@
+cmake --trace  -G "MinGW Makefiles" \
+	-DCMAKE_MAKE_PROGRAM=$NDKROOT/prebuilt/windows-x86_64/bin/make.exe \
+	-DCMAKE_BUILD_TYPE=Debug \
+	-DANDROID_ABI=arm64-v8a \
+	-DANDROID_NATIVE_API_LEVEL=android-22 \
+	-DANDROID_FORCE_ARM_BUILD=TRUE \
+	-DCMAKE_INSTALL_PREFIX=install \
+	-DANDROID_STL=c++_shared \
+	-DANDROID_STL_FORCE_FEATURES=ON \
+	-DCMAKE_TOOLCHAIN_FILE=$NDKROOT/build/cmake/android.toolchain.cmake \
+	-DANDROID_TOOLCHAIN=clang
+$NDKROOT/prebuilt/windows-x86_64/bin/make.exe -j12
+


### PR DESCRIPTION
Some binary GLTF files have a "buffers" section in the JSON instead of having the binary in a separate chunk. This patch supports this type of GLTF.